### PR TITLE
Версия phpcs для php 8.4

### DIFF
--- a/RUVENTS/ruleset.xml
+++ b/RUVENTS/ruleset.xml
@@ -76,7 +76,6 @@
     <rule ref="Generic.Formatting.SpaceAfterCast"/>
     <rule ref="Generic.Formatting.SpaceBeforeCast"/>
     <rule ref="Generic.Formatting.SpaceAfterNot"/>
-    <rule ref="Generic.Functions.CallTimePassByReference"/>
     <rule ref="Generic.Functions.FunctionCallArgumentSpacing"/>
     <rule ref="Generic.Functions.OpeningFunctionBraceBsdAllman"/>
     <rule ref="Generic.Metrics.CyclomaticComplexity">
@@ -258,7 +257,6 @@
     <rule ref="Squiz.Classes.ClassFileName">
         <exclude-pattern>*/migrations/*</exclude-pattern>
     </rule>
-    <rule ref="Squiz.Classes.DuplicateProperty"/>
     <rule ref="Squiz.Classes.LowercaseClassKeywords"/>
     <rule ref="Squiz.Classes.SelfMemberReference"/>
     <rule ref="Squiz.Classes.ValidClassName">
@@ -332,9 +330,7 @@
     <rule ref="Squiz.NamingConventions.ValidVariableName">
         <exclude name="Squiz.NamingConventions.ValidVariableName.PrivateNoUnderscore"/>
     </rule>
-    <rule ref="Squiz.Objects.DisallowObjectStringIndex"/>
     <!--<rule ref="Squiz.Objects.ObjectInstantiation"/>-->
-    <rule ref="Squiz.Objects.ObjectMemberComma"/>
     <rule ref="Squiz.Operators.ComparisonOperatorUsage">
         <exclude name="Squiz.Operators.ComparisonOperatorUsage.ImplicitTrue"/>
     </rule>
@@ -397,7 +393,6 @@
             <property name="ignoreNewlines" type="bool" value="true"/>
         </properties>
     </rule>
-    <rule ref="Squiz.WhiteSpace.PropertyLabelSpacing"/>
     <rule ref="Squiz.WhiteSpace.ScopeClosingBrace"/>
     <rule ref="Squiz.WhiteSpace.ScopeKeywordSpacing"/>
     <rule ref="Squiz.WhiteSpace.SemicolonSpacing"/>

--- a/RUVENTS/ruleset.xml
+++ b/RUVENTS/ruleset.xml
@@ -390,7 +390,6 @@
         <properties>
             <property name="spacing" type="int" value="1"/>
             <property name="spacingBeforeFirst" type="int" value="0"/>
-            <property name="ignoreNewlines" type="bool" value="true"/>
         </properties>
     </rule>
     <rule ref="Squiz.WhiteSpace.OperatorSpacing">
@@ -404,12 +403,8 @@
     <rule ref="Squiz.WhiteSpace.SemicolonSpacing"/>
     <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace"/>
 
-    <!-- PSR2R -->
-    <rule ref="PSR2R.Classes.ClassCreateInstance"/>
-    <rule ref="PSR2R.Classes.ClassFileName"/>
     <!--<rule ref="PSR2R.Classes.InterfaceName"/> toDo: Спорная вещь. Обсудить... -->
     <rule ref="PSR2R.Classes.PropertyDeclaration"/>
-    <rule ref="PSR2R.Classes.SelfAccessor"/>
     <!--<rule ref="PSR2R.Classes.TraitName"/> toDo: Спорная вещь. Обсудить... -->
 
     <rule ref="SlevomatCodingStandard.Functions">

--- a/RUVENTS/ruleset.xml
+++ b/RUVENTS/ruleset.xml
@@ -384,7 +384,7 @@
             <property name="spacingAfterLast" type="int" value="0"/>
         </properties>
     </rule>
-    <rule ref="Squiz.WhiteSpace.LanguageConstructSpacing"/>
+    <rule ref="Generic.WhiteSpace.LanguageConstructSpacing"/>
     <rule ref="Squiz.WhiteSpace.LogicalOperatorSpacing"/>
     <rule ref="Squiz.WhiteSpace.MemberVarSpacing">
         <properties>
@@ -410,6 +410,10 @@
     <rule ref="SlevomatCodingStandard.Functions">
         <!-- Рано такое делать. IDEA/PhpStorm не умеют форматировать такие... -->
         <exclude name="SlevomatCodingStandard.Functions.TrailingCommaInCall.MissingTrailingComma"/>
+        <!--Некоторые функции нельзя укоротить до 20 строк, а разбивать их - бессмыслица-->
+        <exclude name="SlevomatCodingStandard.Functions.FunctionLength.FunctionLength"/>
+        <!--Противоречит другому правилу многострочного вызова, при этом на однострочном вызове все равно будет ошибка, напоминающая о лишней запятой-->
+        <exclude name="SlevomatCodingStandard.Functions.DisallowTrailingCommaInCall.DisallowedTrailingComma"/>
     </rule>
 
     <rule ref="Zend.Files.ClosingTag">

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "frogbarbarian/codestyle",
+  "name": "ruvents/codestyle",
   "license": "MIT",
   "description": "Корпоративный стандарт оформления кода.",
   "type": "phpcodesniffer-standard",
@@ -23,7 +23,7 @@
     ]
   },
   "require": {
-    "php": ">=8",
+    "php": "8.4.*",
     "ext-json": "*",
     "squizlabs/php_codesniffer": "3.13.*",
     "slevomat/coding-standard": "8.18.*",

--- a/composer.json
+++ b/composer.json
@@ -23,16 +23,20 @@
     ]
   },
   "require": {
-    "php": ">=7.1",
+    "php": ">=8",
     "ext-json": "*",
-    "squizlabs/php_codesniffer": "3.5.8",
-    "slevomat/coding-standard": "6.4.1",
-    "fig-r/psr2r-sniffer": "0.5.0",
-    "pheromone/phpcs-security-audit": "2.0.1",
+    "squizlabs/php_codesniffer": "3.13.*",
+    "slevomat/coding-standard": "8.18.*",
+    "fig-r/psr2r-sniffer": "2.2.*",
     "escapestudios/symfony2-coding-standard": "3.11.0"
   },
   "require-dev": {
     "roave/security-advisories": "dev-master",
-    "symfony/finder": "5.0.4"
+    "symfony/finder": "7.2.*"
+  },
+  "config": {
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": false
+    }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "ruvents/codestyle",
+  "name": "frogbarbarian/codestyle",
   "license": "MIT",
   "description": "Корпоративный стандарт оформления кода.",
   "type": "phpcodesniffer-standard",


### PR DESCRIPTION
# Обновляет набор пакетов
# Пакет pheromone/phpcs-security-audit удален из-за отсутствия поддержки
# Обновлен набор правил